### PR TITLE
ref + убрал примитивы

### DIFF
--- a/hw04-garbage-collector/build.gradle
+++ b/hw04-garbage-collector/build.gradle
@@ -1,0 +1,6 @@
+plugins {
+    id 'java'
+}
+
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17

--- a/hw04-garbage-collector/src/main/java/ru/otus/calculator/CalcDemo.java
+++ b/hw04-garbage-collector/src/main/java/ru/otus/calculator/CalcDemo.java
@@ -1,0 +1,39 @@
+package ru.otus.calculator;
+
+
+/*
+-Xms256m
+-Xmx256m
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:HeapDumpPath=./logs/heapdump.hprof
+-XX:+UseG1GC
+-Xlog:gc=debug:file=./logs/gc-%p-%t.log:tags,uptime,time,level:filecount=5,filesize=10m
+*/
+
+
+import java.time.LocalDateTime;
+
+public class CalcDemo {
+    public static void main(String[] args) {
+        long counter = 100_000_000;
+        var summator = new Summator();
+        long startTime = System.currentTimeMillis();
+
+        for (var idx = 0; idx < counter; idx++) {
+            var data = new Data(idx);
+            summator.calc(data);
+
+            if (idx % 10_000_000 == 0) {
+                System.out.println(LocalDateTime.now() + " current idx:" + idx);
+            }
+        }
+
+        long delta = System.currentTimeMillis() - startTime;
+        System.out.println(summator.getPrevValue());
+        System.out.println(summator.getPrevPrevValue());
+        System.out.println(summator.getSumLastThreeValues());
+        System.out.println(summator.getSomeValue());
+        System.out.println(summator.getSum());
+        System.out.println("spend msec:" + delta + ", sec:" + (delta / 1000));
+    }
+}

--- a/hw04-garbage-collector/src/main/java/ru/otus/calculator/Data.java
+++ b/hw04-garbage-collector/src/main/java/ru/otus/calculator/Data.java
@@ -1,0 +1,4 @@
+package ru.otus.calculator;
+
+public record Data(int value) {
+}

--- a/hw04-garbage-collector/src/main/java/ru/otus/calculator/Summator.java
+++ b/hw04-garbage-collector/src/main/java/ru/otus/calculator/Summator.java
@@ -1,0 +1,54 @@
+package ru.otus.calculator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Summator {
+    private int sum;
+    private int prevValue;
+    private int prevPrevValue;
+    private int sumLastThreeValues;
+    private int someValue;
+    private final List<Data> listValues = new ArrayList<>();
+
+    //!!! сигнатуру метода менять нельзя
+    public void calc(Data data) {
+
+
+        listValues.add(data);
+        if (listValues.size() % 6_600_000 == 0) {
+            listValues.clear();
+        }
+        sum += data.value();
+
+        sumLastThreeValues = data.value() + prevValue + prevPrevValue;
+
+        prevPrevValue = prevValue;
+        prevValue = data.value();
+
+        for (var idx = 0; idx < 3; idx++) {
+            someValue += (sumLastThreeValues * sumLastThreeValues / (data.value() + 1) - sum);
+            someValue = Math.abs(someValue) + listValues.size();
+        }
+    }
+
+    public Integer getSum() {
+        return sum;
+    }
+
+    public Integer getPrevValue() {
+        return prevValue;
+    }
+
+    public Integer getPrevPrevValue() {
+        return prevPrevValue;
+    }
+
+    public Integer getSumLastThreeValues() {
+        return sumLastThreeValues;
+    }
+
+    public Integer getSomeValue() {
+        return someValue;
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,4 +2,6 @@ rootProject.name = 'otusJava'
 include 'hw01-gradle'
 include 'hw02-generics'
 include 'hw03-annotations'
-include 'hw04-gc'
+include 'hw04-garbage-collector'
+
+


### PR DESCRIPTION
Результаты замеров до оптимизации:

G1GC
256m - dont start
512m - 13sec / 13sec/ 14sec
768m - 14sec/ 12sec/ 14sec
1024m - 13sec/ 12sec/ 13sec
1536m - 12sec/ 11sec/ 11sec
2048m - 11sec/ 12sec/ 11sec

SerialGC
512m - 13sec
1024m - 10sec

ParallelGC
512m - 17sec
1024m - 14sec

Оптимальный размер хипа для G1GC между 1024 - 1536

Выполнил рефакторинг кода для ускорения работы GC - убрал обертки над примитивами в БЛ,  
в геттерах оставил для примера - так как существенного влияния на скорость работы GC не оказывают.